### PR TITLE
[MMO-197] Add larger disk profile, since we often have to +200GB

### DIFF
--- a/salt/control/virt.yml
+++ b/salt/control/virt.yml
@@ -45,3 +45,6 @@ parameters:
       xxxlarge:
         - system:
             size: 500000
+      xxxxlarge:
+        - system:
+            size: 700000


### PR DESCRIPTION
Add larger disk profile, since we often have to +200GB influx and log servers anyways on some of our larger sites