### PR TITLE
Fix dns system codename

### DIFF
--- a/reclass/storage/system/openstack_dns_cluster.yml
+++ b/reclass/storage/system/openstack_dns_cluster.yml
@@ -12,7 +12,7 @@ parameters:
           - cluster.${_param:cluster_name}.openstack.dns
           params:
             salt_master_host: ${_param:reclass_config_master}
-            linux_system_codename: xenial
+            linux_system_codename: trusty
             single_address: ${_param:openstack_dns_node01_address}
             keepalived_vip_priority: 110
         openstack_dns_node02:
@@ -22,6 +22,6 @@ parameters:
           - cluster.${_param:cluster_name}.openstack.dns
           params:
             salt_master_host: ${_param:reclass_config_master}
-            linux_system_codename: xenial
+            linux_system_codename: trusty
             single_address: ${_param:openstack_dns_node02_address}
             keepalived_vip_priority: 111

--- a/reclass/storage/system/openstack_dns_cluster.yml
+++ b/reclass/storage/system/openstack_dns_cluster.yml
@@ -12,7 +12,7 @@ parameters:
           - cluster.${_param:cluster_name}.openstack.dns
           params:
             salt_master_host: ${_param:reclass_config_master}
-            linux_system_codename: trusty
+            linux_system_codename: xenial
             single_address: ${_param:openstack_dns_node01_address}
             keepalived_vip_priority: 110
         openstack_dns_node02:
@@ -22,6 +22,6 @@ parameters:
           - cluster.${_param:cluster_name}.openstack.dns
           params:
             salt_master_host: ${_param:reclass_config_master}
-            linux_system_codename: trusty
+            linux_system_codename: xenial
             single_address: ${_param:openstack_dns_node02_address}
             keepalived_vip_priority: 111


### PR DESCRIPTION
Changes linux_system_codename in reclass.storage.system.openstack_dns_cluster from trusty to xenial. Now matches default image set in salt.control.cluster.openstack_dns_cluster.

This is in response to issue #285  
