### PR TITLE
Openssh server value in team members user declarations

### DIFF
--- a/openssh/server/team/members/korlowska.yml
+++ b/openssh/server/team/members/korlowska.yml
@@ -11,7 +11,6 @@ parameters:
           email: korlowska@mirantis.com
   openssh:
     server:
-      enabled: false
       user:
         korlowska:
           enabled: true

--- a/openssh/server/team/members/korlowska.yml
+++ b/openssh/server/team/members/korlowska.yml
@@ -11,7 +11,7 @@ parameters:
           email: korlowska@mirantis.com
   openssh:
     server:
-      enabled: true
+      enabled: false
       user:
         korlowska:
           enabled: true

--- a/openssh/server/team/members/miwinski.yml
+++ b/openssh/server/team/members/miwinski.yml
@@ -11,7 +11,7 @@ parameters:
           email: miwinski@mirantis.com
   openssh:
     server:
-      enabled: true
+      enabled: false
       user:
         miwinski:
           enabled: true

--- a/openssh/server/team/members/miwinski.yml
+++ b/openssh/server/team/members/miwinski.yml
@@ -11,7 +11,6 @@ parameters:
           email: miwinski@mirantis.com
   openssh:
     server:
-      enabled: false
       user:
         miwinski:
           enabled: true

--- a/openssh/server/team/members/mlos.yml
+++ b/openssh/server/team/members/mlos.yml
@@ -11,7 +11,6 @@ parameters:
           email: mlos@mirantis.com
   openssh:
     server:
-      enabled: false
       user:
         mlos:
           enabled: true

--- a/openssh/server/team/members/mlos.yml
+++ b/openssh/server/team/members/mlos.yml
@@ -11,7 +11,7 @@ parameters:
           email: mlos@mirantis.com
   openssh:
     server:
-      enabled: true
+      enabled: false
       user:
         mlos:
           enabled: true

--- a/openssh/server/team/members/mniedbala.yml
+++ b/openssh/server/team/members/mniedbala.yml
@@ -11,7 +11,7 @@ parameters:
           email: mniedbala@mirantis.com
   openssh:
     server:
-      enabled: true
+      enabled: false
       user:
         mniedbala:
           enabled: true

--- a/openssh/server/team/members/mniedbala.yml
+++ b/openssh/server/team/members/mniedbala.yml
@@ -11,7 +11,6 @@ parameters:
           email: mniedbala@mirantis.com
   openssh:
     server:
-      enabled: false
       user:
         mniedbala:
           enabled: true

--- a/openssh/server/team/members/pruzicka.yml
+++ b/openssh/server/team/members/pruzicka.yml
@@ -11,7 +11,6 @@ parameters:
           email: pruzicka@mirantis.com
   openssh:
     server:
-      enabled: false
       user:
         pruzicka:
           enabled: true

--- a/openssh/server/team/members/pruzicka.yml
+++ b/openssh/server/team/members/pruzicka.yml
@@ -11,7 +11,7 @@ parameters:
           email: pruzicka@mirantis.com
   openssh:
     server:
-      enabled: true
+      enabled: false
       user:
         pruzicka:
           enabled: true


### PR DESCRIPTION
Corrected pruzicka and my team members files to a proper value.
As suggested by @epcim in:
https://github.com/Mirantis/reclass-system-salt-model/pull/295

Pruzicka file is used as an example in onbarding wiki, so that should prevent any future mistakes.