### PR TITLE
Parameterize cluster hostnames

### DIFF
--- a/haproxy/proxy/listen/openstack/aodh.yml
+++ b/haproxy/proxy/listen/openstack/aodh.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8042
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8042
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8042
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8042
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/barbican.yml
+++ b/haproxy/proxy/listen/openstack/barbican.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9311
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9311
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9311
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9311
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -28,15 +28,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9312
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9312
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9312
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9312
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/cinder.yml
+++ b/haproxy/proxy/listen/openstack/cinder.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8776
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8776
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8776
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8776
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/glance.yml
+++ b/haproxy/proxy/listen/openstack/glance.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9292
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9292
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9292
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9292
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -28,15 +28,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9191
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9191
             params: check
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9191
             params: check
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9191
             params: check

--- a/haproxy/proxy/listen/openstack/glare.yml
+++ b/haproxy/proxy/listen/openstack/glare.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9494
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9494
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9494
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9494
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/heat.yml
+++ b/haproxy/proxy/listen/openstack/heat.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8003
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8003
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8003
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8003
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -28,15 +28,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8004
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8004
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8004
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8004
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -47,15 +47,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8000
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/horizon.yml
+++ b/haproxy/proxy/listen/openstack/horizon.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8078
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8078
             params: check
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8078
             params: check
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8078
             params: check

--- a/haproxy/proxy/listen/openstack/ironic.yml
+++ b/haproxy/proxy/listen/openstack/ironic.yml
@@ -10,15 +10,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 6385
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 6385
             params: check
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 6385
             params: check
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 6385
             params: check

--- a/haproxy/proxy/listen/openstack/keystone/init.yml
+++ b/haproxy/proxy/listen/openstack/keystone/init.yml
@@ -7,15 +7,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 5000
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 5000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 5000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 5000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -24,15 +24,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 35357
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 35357
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 35357
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 35357
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/neutron.yml
+++ b/haproxy/proxy/listen/openstack/neutron.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9696
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/nova-placement.yml
+++ b/haproxy/proxy/listen/openstack/nova-placement.yml
@@ -15,15 +15,15 @@ parameters:
               options:
               - expect status 401
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8778
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8778
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8778
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/nova.yml
+++ b/haproxy/proxy/listen/openstack/nova.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8774
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8774
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8774
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8774
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
@@ -27,15 +27,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8775
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8775
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8775
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8775
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/novnc.yml
+++ b/haproxy/proxy/listen/openstack/novnc.yml
@@ -10,15 +10,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 6080
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 6080
             params: check
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 6080
             params: check
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 6080
             params: check

--- a/haproxy/proxy/listen/openstack/octavia.yml
+++ b/haproxy/proxy/listen/openstack/octavia.yml
@@ -9,15 +9,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9876
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9876
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9876
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9876
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/haproxy/proxy/listen/openstack/sahara.yml
+++ b/haproxy/proxy/listen/openstack/sahara.yml
@@ -10,15 +10,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 8386
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 8386
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 8386
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 8386
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/neutron/control/cluster.yml
+++ b/neutron/control/cluster.yml
@@ -21,15 +21,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9696
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3

--- a/neutron/control/openvswitch/cluster.yml
+++ b/neutron/control/openvswitch/cluster.yml
@@ -47,15 +47,15 @@ parameters:
           - address: ${_param:cluster_vip_address}
             port: 9696
           servers:
-          - name: ctl01
+          - name: ${_param:cluster_node01_hostname}
             host: ${_param:cluster_node01_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl02
+          - name: ${_param:cluster_node02_hostname}
             host: ${_param:cluster_node02_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-          - name: ctl03
+          - name: ${_param:cluster_node03_hostname}
             host: ${_param:cluster_node03_address}
             port: 9696
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3


### PR DESCRIPTION
On very rare occassions, we might want to override cluster hostnames.
Tested by squashing multiple roles (mdb, ctl) onto a single host.