### PR TITLE
mongodb: Parameterize cluster hostnames

### DIFF
--- a/.releasenotes/notes/parametric-telemetry-hostnames-06e14467d9a9077d.yaml
+++ b/.releasenotes/notes/parametric-telemetry-hostnames-06e14467d9a9077d.yaml
@@ -1,0 +1,15 @@
+---
+upgrades:
+  - mongodb.server.cluster no longer hardcodes the telemetry nodes' hostnames
+    in favor of using `openstack_telemetry_node{01,02,03}_hostname` params,
+    allowing custom hostnames to be used.
+
+    Configuration example:
+
+    .. code-block:: yaml
+
+        parameters:
+          _param:
+            openstack_telemetry_node01_hostname: mdb01
+            openstack_telemetry_node02_hostname: mdb02
+            openstack_telemetry_node03_hostname: mdb03

--- a/mongodb/server/cluster.yml
+++ b/mongodb/server/cluster.yml
@@ -2,10 +2,13 @@ classes:
 - service.mongodb.server.cluster
 parameters:
   _param:
+    openstack_telemetry_node01_hostname: mdb01
+    openstack_telemetry_node02_hostname: mdb02
+    openstack_telemetry_node03_hostname: mdb03
     mongodb_server_replica_set: mongodb
-    mongodb_master: mdb01
+    mongodb_master: ${_param:openstack_telemetry_node01_hostname}
     mongodb_server_members:
-    - host: mdb01
+    - host: ${_param:openstack_telemetry_node01_hostname}
       priority: 2
-    - host: mdb02
-    - host: mdb03
+    - host: ${_param:openstack_telemetry_node02_hostname}
+    - host: ${_param:openstack_telemetry_node03_hostname}


### PR DESCRIPTION
Replace mdb{01,02,03} with reclass params
openstack_telemetry_node{01,02,03}_hostname.